### PR TITLE
Update profile-collector script to fix event collection of Rancher pods

### DIFF
--- a/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
+++ b/collection/rancher/v2.x/profile-collector/continuous_profiling.sh
@@ -75,7 +75,7 @@ while true; do
 		fi
 
 		echo Getting rancher-event-logs for $pod
-		kubectl events --for pod/$pod -n cattle-system >${TMPDIR}/${pod}-events.log
+		kubectl get event --namespace cattle-system --field-selector involvedObject.name=${pod} >${TMPDIR}/${pod}-events.log		
 		echo
 
 		echo Getting describe for $pod


### PR DESCRIPTION
Fixed the line to get events for the pod which was giving me this error `error: unknown command "events" for "kubectl"`